### PR TITLE
remove default namespace while creating dns pod

### DIFF
--- a/tools/preflight/preflight.sh
+++ b/tools/preflight/preflight.sh
@@ -298,7 +298,6 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: dnsutils
-  namespace: default
 spec:
   containers:
   - name: dnsutils


### PR DESCRIPTION
- remove `default` namespace from dnsutil pod manifest so that current namespace is used by default